### PR TITLE
Remove gw5-gw8

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -137,38 +137,6 @@
                 'ipv6 "gw4.saar.freifunk.net" port 10003',
 	    },
           },
-
-          gw5 = {
-            key = '869e3049efed00b890cdc6e085a453fbc320b0528489cc0bee91ed29d0865dfe',
-            remotes = {
-                'ipv4 "gw5.saar.freifunk.net" port 10003', 
-                'ipv6 "gw5.saar.freifunk.net" port 10003',
-	    },
-          },
-
-          gw6 = {
-            key = 'f29968ba7a58de84e05c14b9b2d5eaa65326b7e85106a022644c5c843287048a',
-            remotes = {
-                'ipv4 "gw6.saar.freifunk.net" port 10003', 
-                'ipv6 "gw6.saar.freifunk.net" port 10003',
-	    },
-          },
-
-          gw7 = {
-            key = 'fe0b1f78395b1f49ddf3480593ec741afd07998a73bffa543cf8c4e7ee3aadbc',
-            remotes = {
-                'ipv4 "gw7.saar.freifunk.net" port 10003', 
-                'ipv6 "gw7.saar.freifunk.net" port 10003',
-	    },
-          },
-
-          gw8 = {
-            key = '9a02502c040a9184f12789da88209d4e91412de3be36664fc0290be5437b74ab',
-            remotes = {
-                'ipv4 "gw8.saar.freifunk.net" port 10003', 
-                'ipv6 "gw8.saar.freifunk.net" port 10003',
-	    },
-          },
         },
       },
     },


### PR DESCRIPTION
We won't need them in near future and adding them has some small negative side-effects:
- Nodes try to connect to them and waste time on resolving -> increases initial startup time
- peers are shown on router status page -> UI might confuse users, minimally increases workload for creating status page

We can still keep the keys and revert this change once we need it.
